### PR TITLE
Supa actions

### DIFF
--- a/src/elm/Actor/Component/CollectorComponent.elm
+++ b/src/elm/Actor/Component/CollectorComponent.elm
@@ -65,7 +65,17 @@ collect collectorData actor position level =
                 |> List.filter (\foundActor -> foundActor.id /= actor.id)
                 |> List.filterMap withCollectibleData
                 |> List.filter collectiblePredicates
+    in
+    if List.length collectibleActors > 0 then
+        doCollect collectorData actor collectibleActors level
 
+    else
+        ( actor, level )
+
+
+doCollect : CollectorComponentData -> Actor -> List ( Actor, CollectibleComponentData ) -> Level -> ( Actor, Level )
+doCollect collectorData actor collectibleActors level =
+    let
         updatedCollectorData : CollectorComponentData
         updatedCollectorData =
             collectAll collectorData collectibleActors

--- a/src/elm/Actor/Component/ControlComponent.elm
+++ b/src/elm/Actor/Component/ControlComponent.elm
@@ -11,6 +11,7 @@ import Actor.Actor as Actor
         , WalkAroundAiControlData
         )
 import Actor.Common as Common
+import Actor.Component.CollectorComponent as CollectorComponent
 import Actor.Component.MovementComponent as MovementComponent
 import Actor.Component.PhysicsComponent as Physics
 import Actor.Component.RigidComponent as Rigid
@@ -219,15 +220,13 @@ handleStationedDirection level actor direction =
 
         -- Only one actor
         [ otherActor ] ->
-            if canBeWalkedOver actor otherActor then
-                -- Maybe we can consume @todo implement
-                level
-
-            else if canPush actor otherActor direction level then
+            if canPush actor otherActor direction level then
                 MovementComponent.startMovingTowards otherActor direction level
 
             else
-                level
+                Common.getPosition otherActor
+                    |> Maybe.map (\otherActorPosition -> CollectorComponent.tryCollectPosition actor otherActorPosition level)
+                    |> Maybe.withDefault level
 
         -- Multiple actors. There is no implementation for that scenario
         _ ->

--- a/src/elm/Actor/Component/ControlComponent.elm
+++ b/src/elm/Actor/Component/ControlComponent.elm
@@ -90,7 +90,7 @@ withActor actor action =
 getInputControlAction : InputController.Model -> Actor -> Maybe ( Action, Actor )
 getInputControlAction inputController actor =
     InputController.getCurrentDirection inputController
-        |> Maybe.map (\direction -> { direction = direction, peak = InputController.isKeyPressed inputController InputController.spaceKey })
+        |> Maybe.map (\direction -> { direction = direction, peak = InputController.isKeyPressed inputController InputController.submitKey })
         |> Maybe.map (withActor actor)
 
 

--- a/src/elm/Actor/Component/MovementComponent.elm
+++ b/src/elm/Actor/Component/MovementComponent.elm
@@ -2,6 +2,7 @@ module Actor.Component.MovementComponent exposing
     ( calculateCompletionPercentage
     , init
     , isActorMoving
+    , isActorNotMoving
     , isMoving
     , isMovingAt
     , isMovingDown
@@ -119,6 +120,11 @@ isActorMoving actor =
     Common.getMovementComponent actor
         |> Maybe.map isMoving
         |> Maybe.withDefault False
+
+
+isActorNotMoving : Actor -> Bool
+isActorNotMoving =
+    isActorMoving >> not
 
 
 isMoving : MovementComponentData -> Bool

--- a/src/elm/Actor/LevelUpdate.elm
+++ b/src/elm/Actor/LevelUpdate.elm
@@ -16,9 +16,10 @@ import Actor.Component.TriggerExplodableComponent as TriggerExplodable
 import Data.Coordinate as Coordinate
 import Data.Direction exposing (Direction)
 import Dict
+import InputController
 
 
-update : Maybe Direction -> Level -> LevelConfig -> Level
+update : InputController.Model -> Level -> LevelConfig -> Level
 update controllerInput levelBeforeUpdate levelConfig =
     let
         view =
@@ -54,7 +55,7 @@ update controllerInput levelBeforeUpdate levelConfig =
         yPositions
 
 
-updateActorsAtPosition : LevelConfig -> Level -> Maybe Direction -> Int -> Int -> Level -> Level
+updateActorsAtPosition : LevelConfig -> Level -> InputController.Model -> Int -> Int -> Level -> Level
 updateActorsAtPosition levelConfig levelBeforeUpdate controllerInput x y level =
     let
         preparedUpdateActorById =
@@ -66,7 +67,7 @@ updateActorsAtPosition levelConfig levelBeforeUpdate controllerInput x y level =
             level
 
 
-updateActorById : LevelConfig -> Level -> Maybe Direction -> Level -> ActorId -> Level
+updateActorById : LevelConfig -> Level -> InputController.Model -> Level -> ActorId -> Level
 updateActorById levelConfig levelBeforeUpdate controllerInput level actorId =
     let
         preparedUpdateComponent =
@@ -87,7 +88,7 @@ updateActorById levelConfig levelBeforeUpdate controllerInput level actorId =
         |> Maybe.withDefault level
 
 
-updateComponent : LevelConfig -> Level -> Maybe Direction -> Component -> Level -> Actor -> Level
+updateComponent : LevelConfig -> Level -> InputController.Model -> Component -> Level -> Actor -> Level
 updateComponent levelConfig levelBeforeUpdate controllerInput component level actor =
     case component of
         Actor.AiComponent aiData ->

--- a/src/elm/Actor/LevelUpdate.elm
+++ b/src/elm/Actor/LevelUpdate.elm
@@ -14,7 +14,6 @@ import Actor.Component.MovementComponent as Movement
 import Actor.Component.SpawnComponent as Spawn
 import Actor.Component.TriggerExplodableComponent as TriggerExplodable
 import Data.Coordinate as Coordinate
-import Data.Direction exposing (Direction)
 import Dict
 import InputController
 

--- a/src/elm/GameState/PlayingLevel/Completed/CompletedAnimation.elm
+++ b/src/elm/GameState/PlayingLevel/Completed/CompletedAnimation.elm
@@ -56,10 +56,7 @@ updateTick currentTick inputModel model =
                         |> (\a -> setAnimation a animationModel)
                         |> (\a -> setLevel a level)
                         |> (\updatedModel ->
-                                LevelUpdate.update
-                                    (InputController.getCurrentDirection inputModel)
-                                    updatedModel.level
-                                    updatedModel.levelConfig
+                                LevelUpdate.update inputModel updatedModel.level updatedModel.levelConfig
                                     -- We won't handle events
                                     |> EventManager.clearEvents
                                     -- Prevents view movement

--- a/src/elm/GameState/PlayingLevel/Failed/FailedAnimation.elm
+++ b/src/elm/GameState/PlayingLevel/Failed/FailedAnimation.elm
@@ -54,10 +54,7 @@ updateTick currentTick inputModel model =
                         |> (\a -> setAnimation a animationModel)
                         |> (\a -> setLevel a level)
                         |> (\updatedModel ->
-                                LevelUpdate.update
-                                    (InputController.getCurrentDirection inputModel)
-                                    updatedModel.level
-                                    updatedModel.levelConfig
+                                LevelUpdate.update inputModel updatedModel.level updatedModel.levelConfig
                                     -- We won't handle events
                                     |> EventManager.clearEvents
                                     -- Prevents view movement

--- a/src/elm/GameState/PlayingLevel/Playing.elm
+++ b/src/elm/GameState/PlayingLevel/Playing.elm
@@ -55,7 +55,7 @@ updateTick currentTick inputModel model =
 
         _ ->
             LevelUpdate.update
-                (InputController.getCurrentDirection inputModel)
+                inputModel
                 model.level
                 model.levelConfig
                 |> setLevel model

--- a/src/elm/InputController.elm
+++ b/src/elm/InputController.elm
@@ -9,7 +9,7 @@ port module InputController exposing
     , init
     , isKeyPressed
     , resetWasPressed
-    , spaceKey
+    , submitKey
     , subscriptions
     , update
     )
@@ -119,11 +119,6 @@ selectKey =
     "x"
 
 
-spaceKey : KeyCode
-spaceKey =
-    " "
-
-
 keyCodeToDirection : Dict KeyCode Direction
 keyCodeToDirection =
     Dict.fromList
@@ -147,7 +142,6 @@ init =
             , ( startKey, NotPressed )
             , ( escKey, NotPressed )
             , ( selectKey, NotPressed )
-            , ( spaceKey, NotPressed )
             ]
     , counter = 0
     }

--- a/src/elm/InputController.elm
+++ b/src/elm/InputController.elm
@@ -7,10 +7,11 @@ port module InputController exposing
     , getCurrentDirection
     , getOrderedPressedKeys
     , init
+    , isKeyPressed
     , resetWasPressed
+    , spaceKey
     , subscriptions
     , update
-    , isKeyPressed
     )
 
 import Browser.Events
@@ -117,9 +118,10 @@ selectKey : KeyCode
 selectKey =
     "x"
 
+
 spaceKey : KeyCode
 spaceKey =
-    ""
+    " "
 
 
 keyCodeToDirection : Dict KeyCode Direction
@@ -175,13 +177,13 @@ getCurrentDirection model =
                     |> Maybe.map (\counter -> ( counter, direction ))
             )
         |> Maybe.Extra.values
-        |> List.sortBy  (\( code, direction ) -> code)
+        |> List.sortBy (\( code, direction ) -> code)
         |> List.head
         |> Maybe.map Tuple.second
 
 
-isKeyPressed : KeyCode -> Model -> Bool
-isKeyPressed keyCode model =
+isKeyPressed : Model -> KeyCode -> Bool
+isKeyPressed model keyCode =
     case Dict.get keyCode model.keys of
         Just (IsPressed _) ->
             True
@@ -293,7 +295,7 @@ getOrderedPressedKeys model =
                     IsPressed tick ->
                         tick
             )
-        |> List.filter (\( key, status ) -> status /= NotPressed )
+        |> List.filter (\( key, status ) -> status /= NotPressed)
         |> List.map Tuple.first
         |> List.map (\a -> Dict.get a keyMap)
         |> Maybe.Extra.values


### PR DESCRIPTION
- [x] consume stuff

The collector component is correctly updated.
But it is not taken into account in the LevelUpdate loop.
There the components are already taken before.

This failure can happen for all components that can be updated outside their update loop.

The easy approach is to reload the data for certain components in the level update or something. Like movement and collector for now
